### PR TITLE
Added slowmode and fastmode buttons

### DIFF
--- a/src/main/java/frc/robot/commands/SwerveTeleop.java
+++ b/src/main/java/frc/robot/commands/SwerveTeleop.java
@@ -19,16 +19,19 @@ public class SwerveTeleop extends CommandBase {
     private Joystick driverStick;
     private double teleopSpeed;
     private double teleopAngularSpeed;
-    /*private SlewRateLimiter transLimiter = new SlewRateLimiter(3.0);
-    private SlewRateLimiter strafeLimiter = new SlewRateLimiter(3.0);
-    private SlewRateLimiter rotationLimiter = new SlewRateLimiter(3.0);*/
+    private SlewRateLimiter transLimiter; 
+    private SlewRateLimiter strafeLimiter;
+    private SlewRateLimiter rotationLimiter;
     
 
     /** Creates a new DriveCommand. */
-    public SwerveTeleop(Joystick driverStick, double teleopSpeed, double teleopAngularSpeed) {
+    public SwerveTeleop(Joystick driverStick, double teleopSpeed, double teleopAngularSpeed, double rateLimit) {
         this.driverStick = driverStick;
         this.teleopAngularSpeed = teleopAngularSpeed;
         this.teleopSpeed = teleopSpeed;
+        transLimiter = new SlewRateLimiter(rateLimit);
+        strafeLimiter = new SlewRateLimiter(rateLimit);
+        rotationLimiter = new SlewRateLimiter(rateLimit);
         addRequirements(SwerveSubsystem.getInstance());
 
     } 
@@ -51,9 +54,9 @@ public class SwerveTeleop extends CommandBase {
         y = MathUtil.applyDeadband(y, Config.DRIVER_JOYSTICK_DEADBAND);
         rot = MathUtil.applyDeadband(rot, Config.DRIVER_JOYSTICK_DEADBAND);
 
-        /*x = transLimiter.calculate(x);
+        x = transLimiter.calculate(x);
         y = strafeLimiter.calculate(y);
-        rot = rotationLimiter.calculate(rot);*/
+        rot = rotationLimiter.calculate(rot);
     
         
         SwerveSubsystem.getInstance().drive(

--- a/src/main/java/frc/robot/commands/SwerveTeleop.java
+++ b/src/main/java/frc/robot/commands/SwerveTeleop.java
@@ -17,14 +17,18 @@ import frc.robot.subsystems.SwerveSubsystem;
 
 public class SwerveTeleop extends CommandBase {
     private Joystick driverStick;
+    private double teleopSpeed;
+    private double teleopAngularSpeed;
     /*private SlewRateLimiter transLimiter = new SlewRateLimiter(3.0);
     private SlewRateLimiter strafeLimiter = new SlewRateLimiter(3.0);
     private SlewRateLimiter rotationLimiter = new SlewRateLimiter(3.0);*/
     
 
     /** Creates a new DriveCommand. */
-    public SwerveTeleop(Joystick driverStick) {
+    public SwerveTeleop(Joystick driverStick, double teleopSpeed, double teleopAngularSpeed) {
         this.driverStick = driverStick;
+        this.teleopAngularSpeed = teleopAngularSpeed;
+        this.teleopSpeed = teleopSpeed;
         addRequirements(SwerveSubsystem.getInstance());
 
     } 
@@ -53,9 +57,9 @@ public class SwerveTeleop extends CommandBase {
     
         
         SwerveSubsystem.getInstance().drive(
-            x * Config.Swerve.teleopSpeed,
-            y * Config.Swerve.teleopSpeed,
-            rot * Config.Swerve.kMaxTeleopAngularSpeed,
+            x * teleopSpeed,
+            y * teleopSpeed,
+            rot * teleopAngularSpeed,
             true, true);
     }
 

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -215,11 +215,14 @@ public class Config {
             new Translation2d(-kWheelBase / 2, kTrackWidth / 2),
             new Translation2d(-kWheelBase / 2, -kTrackWidth / 2));
 
+        public static final double teleopFastSpeed = 3.0;
+        public static final double teleopFastAngularSpeed = Math.PI*3.0;
+
         public static final double teleopSlowSpeed = 0.3;
         public static final double teleopSlowAngularSpeed = 0.3;
-        public static final double teleopSpeed = 3.0;
-        public static final double teleopAngularSpeed = Math.PI*2.5;
-        public static final double kMaxAttainableAngularSpeed = 3.0;
+        public static final double teleopSpeed = 2.0;
+        public static final double teleopAngularSpeed = Math.PI*2.0;
+        public static final double kMaxAttainableAngularSpeed = Math.PI*3.0;
         public static final double kMaxAttainableWheelSpeed = 3.0;
         public static final double kMaxAutoSpeed = 3; // m/s
         public static final double kMaxAutoAcceleration = 3; // m/s/s

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -128,7 +128,7 @@ public class Config {
 
     public static class Swerve{
         public static final int steeringCurrentLimit = 20;
-        public static final int driveCurrentLimit = 60;
+        public static final int driveCurrentLimit = 50;
 
         public static final double driveVoltComp = 12.0;
         public static final double steeringVoltComp = 12.0;
@@ -215,8 +215,11 @@ public class Config {
             new Translation2d(-kWheelBase / 2, kTrackWidth / 2),
             new Translation2d(-kWheelBase / 2, -kTrackWidth / 2));
 
+        public static final double teleopSlowSpeed = 0.3;
+        public static final double teleopSlowAngularSpeed = 0.3;
         public static final double teleopSpeed = 3.0;
-        public static final double kMaxTeleopAngularSpeed = Math.PI*2.5;
+        public static final double teleopAngularSpeed = Math.PI*2.5;
+        public static final double kMaxAttainableAngularSpeed = 3.0;
         public static final double kMaxAttainableWheelSpeed = 3.0;
         public static final double kMaxAutoSpeed = 3; // m/s
         public static final double kMaxAutoAcceleration = 3; // m/s/s

--- a/src/main/java/frc/robot/robotcontainers/MiniSwerveContainer.java
+++ b/src/main/java/frc/robot/robotcontainers/MiniSwerveContainer.java
@@ -14,6 +14,7 @@ import frc.robot.auto.AutoSelector;
 import frc.robot.commands.ModuleAngleFromJoystick;
 import frc.robot.commands.ResetGyro;
 import frc.robot.commands.SwerveTeleop;
+import frc.robot.config.Config;
 import frc.robot.subsystems.SwerveModule;
 import frc.robot.subsystems.SwerveSubsystem;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -48,7 +49,7 @@ public class MiniSwerveContainer extends RobotContainer{
   private void configureButtonBindings() {
     Joystick driver = new Joystick(0);
 
-    SwerveSubsystem.getInstance().setDefaultCommand(new SwerveTeleop(driver));
+    SwerveSubsystem.getInstance().setDefaultCommand(new SwerveTeleop(driver, Config.Swerve.teleopSpeed, Config.Swerve.teleopAngularSpeed));
 
     new JoystickButton(driver, XboxController.Button.kStart.value).whenPressed(
       new InstantCommand(()-> SwerveSubsystem.getInstance().updateModulesPID())

--- a/src/main/java/frc/robot/robotcontainers/MiniSwerveContainer.java
+++ b/src/main/java/frc/robot/robotcontainers/MiniSwerveContainer.java
@@ -49,7 +49,13 @@ public class MiniSwerveContainer extends RobotContainer{
   private void configureButtonBindings() {
     Joystick driver = new Joystick(0);
 
-    SwerveSubsystem.getInstance().setDefaultCommand(new SwerveTeleop(driver, Config.Swerve.teleopSpeed, Config.Swerve.teleopAngularSpeed));
+    SwerveSubsystem.getInstance().setDefaultCommand(new SwerveTeleop(driver, Config.Swerve.teleopSpeed, Config.Swerve.teleopAngularSpeed,5.0));
+    
+    new JoystickButton(driver, XboxController.Button.kLeftBumper.value).whenHeld(
+      new SwerveTeleop(driver, Config.Swerve.teleopFastSpeed, Config.Swerve.teleopFastAngularSpeed,5.0));
+
+    new JoystickButton(driver, XboxController.Button.kRightBumper.value).whenHeld(
+      new SwerveTeleop(driver, Config.Swerve.teleopSlowSpeed, Config.Swerve.teleopSlowAngularSpeed,20.0));
 
     new JoystickButton(driver, XboxController.Button.kStart.value).whenPressed(
       new InstantCommand(()-> SwerveSubsystem.getInstance().updateModulesPID())
@@ -67,20 +73,20 @@ public class MiniSwerveContainer extends RobotContainer{
     SwerveModuleState state4 = new SwerveModuleState(-0.5, Rotation2d.fromDegrees(0));
 
 
-    Command angleSetPoint1 = new RunCommand(() -> SwerveSubsystem.getInstance().setModuleStates(new SwerveModuleState[]{state1, state1, state1, state1}, true), SwerveSubsystem.getInstance());
-    new JoystickButton(driver, XboxController.Button.kB.value).whenHeld(angleSetPoint1).whenReleased(new InstantCommand(SwerveSubsystem.getInstance() :: stopMotors, SwerveSubsystem.getInstance()));
+    // Command angleSetPoint1 = new RunCommand(() -> SwerveSubsystem.getInstance().setModuleStates(new SwerveModuleState[]{state1, state1, state1, state1}, true), SwerveSubsystem.getInstance());
+    // new JoystickButton(driver, XboxController.Button.kB.value).whenHeld(angleSetPoint1).whenReleased(new InstantCommand(SwerveSubsystem.getInstance() :: stopMotors, SwerveSubsystem.getInstance()));
 
-    Command angleSetPoint2 = new RunCommand(() -> SwerveSubsystem.getInstance().setModuleStates(new SwerveModuleState[]{state2, state1, state1, state1}, true), SwerveSubsystem.getInstance());
-    new JoystickButton(driver, XboxController.Button.kX.value).whenHeld(angleSetPoint2).whenReleased(new InstantCommand(SwerveSubsystem.getInstance() :: stopMotors, SwerveSubsystem.getInstance()));
+    // Command angleSetPoint2 = new RunCommand(() -> SwerveSubsystem.getInstance().setModuleStates(new SwerveModuleState[]{state2, state1, state1, state1}, true), SwerveSubsystem.getInstance());
+    // new JoystickButton(driver, XboxController.Button.kX.value).whenHeld(angleSetPoint2).whenReleased(new InstantCommand(SwerveSubsystem.getInstance() :: stopMotors, SwerveSubsystem.getInstance()));
 
-    Command angleSetPoint3 = new RunCommand(() -> SwerveSubsystem.getInstance().setModuleStates(new SwerveModuleState[]{state2, state2, state2, state2}, true), SwerveSubsystem.getInstance());
-    new JoystickButton(driver, XboxController.Button.kA.value).whenHeld(angleSetPoint3).whenReleased(new InstantCommand(SwerveSubsystem.getInstance() :: stopMotors, SwerveSubsystem.getInstance()));
+    // Command angleSetPoint3 = new RunCommand(() -> SwerveSubsystem.getInstance().setModuleStates(new SwerveModuleState[]{state2, state2, state2, state2}, true), SwerveSubsystem.getInstance());
+    // new JoystickButton(driver, XboxController.Button.kA.value).whenHeld(angleSetPoint3).whenReleased(new InstantCommand(SwerveSubsystem.getInstance() :: stopMotors, SwerveSubsystem.getInstance()));
 
-    Command angleSetPoint4 = new RunCommand(() -> SwerveSubsystem.getInstance().setModuleStates(new SwerveModuleState[]{state3, state3, state3, state3}, true), SwerveSubsystem.getInstance());
-    new JoystickButton(driver, XboxController.Button.kRightBumper.value).whenHeld(angleSetPoint4).whenReleased(new InstantCommand(SwerveSubsystem.getInstance() :: stopMotors, SwerveSubsystem.getInstance()));
+    // Command angleSetPoint4 = new RunCommand(() -> SwerveSubsystem.getInstance().setModuleStates(new SwerveModuleState[]{state3, state3, state3, state3}, true), SwerveSubsystem.getInstance());
+    // new JoystickButton(driver, XboxController.Button.kRightBumper.value).whenHeld(angleSetPoint4).whenReleased(new InstantCommand(SwerveSubsystem.getInstance() :: stopMotors, SwerveSubsystem.getInstance()));
 
-    Command angleSetPoint5 = new RunCommand(() -> SwerveSubsystem.getInstance().setModuleStates(new SwerveModuleState[]{state4, state4, state4, state4}, true), SwerveSubsystem.getInstance());
-    new JoystickButton(driver, XboxController.Button.kLeftBumper.value).whenHeld(angleSetPoint5).whenReleased(new InstantCommand(SwerveSubsystem.getInstance() :: stopMotors, SwerveSubsystem.getInstance()));
+    // Command angleSetPoint5 = new RunCommand(() -> SwerveSubsystem.getInstance().setModuleStates(new SwerveModuleState[]{state4, state4, state4, state4}, true), SwerveSubsystem.getInstance());
+    // new JoystickButton(driver, XboxController.Button.kLeftBumper.value).whenHeld(angleSetPoint5).whenReleased(new InstantCommand(SwerveSubsystem.getInstance() :: stopMotors, SwerveSubsystem.getInstance()));
   }
 
 

--- a/vendordeps/PathplannerLib.json
+++ b/vendordeps/PathplannerLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PathplannerLib.json",
     "name": "PathplannerLib",
-    "version": "2023.3.1",
+    "version": "2023.3.4",
     "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
     "mavenUrls": [
         "https://3015rangerrobotics.github.io/pathplannerlib/repo"
@@ -11,7 +11,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-java",
-            "version": "2023.3.1"
+            "version": "2023.3.4"
         }
     ],
     "jniDependencies": [],
@@ -19,7 +19,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-cpp",
-            "version": "2023.3.1",
+            "version": "2023.3.4",
             "libName": "PathplannerLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,

--- a/vendordeps/Phoenix.json
+++ b/vendordeps/Phoenix.json
@@ -1,7 +1,7 @@
 {
     "fileName": "Phoenix.json",
     "name": "CTRE-Phoenix (v5)",
-    "version": "5.30.3",
+    "version": "5.30.3+23.0.4",
     "frcYear": 2023,
     "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
     "mavenUrls": [
@@ -50,7 +50,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -63,7 +63,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -76,7 +76,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -89,7 +89,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -102,7 +102,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -115,7 +115,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -128,7 +128,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -141,7 +141,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -154,7 +154,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -167,7 +167,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -227,7 +227,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -287,7 +287,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -302,7 +302,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -317,7 +317,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -332,7 +332,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -347,7 +347,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -362,7 +362,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -377,7 +377,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -392,7 +392,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -407,7 +407,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.2",
+            "version": "23.0.4",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,


### PR DESCRIPTION
These are Jamie's changes to add slow mode buttons. He had major merge conflicts with the Jamie-Slowmode branch because it was still in 2022 VSCode so it was easier to just copy over the changes into a new branch.

Added/changed:
 - Regular teleop speed was reduced to 2 m/s
 - Slowmode button added. When the right bumper is held down, the robot will go very slowly and makes it easy to do precise alignment.
 - Fastmode button. When the left bumper is held down, the robot will go to the max speed (3 m/s). This can be used when in the middle of the field in the open space. Should be helpful to get around defense.
 - Uncommented the SlewRateLimiters. 
 - Changed desaturateWheelSpeeds to use the new version which removes the dead-space in the corners of the joystick.

Tested on flat swerve chassis.

Erik: I'm hoping to use this pull request to show what a decent pull request could look like.