### PR TITLE
Rumble operator joystick when arm reaches the pickup position

### DIFF
--- a/src/main/java/frc/robot/commands/PickupJoystickRumble.java
+++ b/src/main/java/frc/robot/commands/PickupJoystickRumble.java
@@ -1,0 +1,63 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.GenericHID.RumbleType;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj2.command.StartEndCommand;
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import frc.robot.config.ArmConfig;
+import frc.robot.config.ArmConfig.ArmSetpoint;
+import frc.robot.subsystems.ArmSubsystem;
+
+public class PickupJoystickRumble extends CommandBase {
+    private final double allowableBotErrorRad = Math.toRadians(3);
+    private final double allowableTopErrorRad = Math.toRadians(3);
+    private final double topLowerBounds;
+    private final double topUpperBounds;
+    private final double botLowerBounds;
+    private final double botUpperBounds;
+
+    private CommandXboxController m_operator;
+
+    private CommandBase rumbleCommand;
+
+    /** Creates a new ArmRumble. */
+    public PickupJoystickRumble(CommandXboxController operator) {
+        m_operator = operator;
+
+        rumbleCommand = new StartEndCommand(
+            () -> m_operator.getHID().setRumble(RumbleType.kBothRumble, 0.3),
+            () -> m_operator.getHID().setRumble(RumbleType.kBothRumble, 0)
+        ).withTimeout(0.2).ignoringDisable(true);
+
+        double[] pickupAngles = ArmSubsystem.getInstance().inverseKinematics(
+            ArmConfig.L1, ArmConfig.L2, ArmSetpoint.PICKUP.getX(), ArmSetpoint.PICKUP.getZ());
+
+        botLowerBounds = pickupAngles[0] - allowableBotErrorRad;
+        botUpperBounds = pickupAngles[0] + allowableBotErrorRad;
+
+        topLowerBounds = pickupAngles[1] - allowableTopErrorRad;
+        topUpperBounds = pickupAngles[1] + allowableTopErrorRad;
+    }
+
+    // Called once the command ends or is interrupted.
+    @Override
+    public void end(boolean interrupted) {
+        if (interrupted == false) {
+            rumbleCommand.schedule();
+        }   
+    }
+
+    // Returns true when the command should end.
+    @Override
+    public boolean isFinished() {
+        double topPos = ArmSubsystem.getInstance().getTopPosition();
+        double botPos = ArmSubsystem.getInstance().getBottomPosition();
+
+        return topPos > topLowerBounds && topPos < topUpperBounds &&
+               botPos > botLowerBounds && botPos < botUpperBounds;
+    }
+}

--- a/src/main/java/frc/robot/robotcontainers/CompRobotContainer.java
+++ b/src/main/java/frc/robot/robotcontainers/CompRobotContainer.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.XboxController.Button;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Commands;
@@ -25,6 +26,7 @@ import frc.robot.commands.ArmFFTestCommand;
 import frc.robot.commands.ChargeStationLock;
 import frc.robot.commands.CheckArmSetpoints;
 import frc.robot.commands.GripperCommand;
+import frc.robot.commands.PickupJoystickRumble;
 import frc.robot.commands.GripperCommand.GRIPPER_INSTRUCTION;
 import frc.robot.commands.ResetGyro;
 import frc.robot.commands.ResetGyroToNearest;
@@ -113,7 +115,7 @@ public class CompRobotContainer extends RobotContainer {
     operator.leftTrigger().onTrue(new ArmCommand(ArmSetpoint.PICKUP_OUTSIDE_FRAME));
 
     // Choose the ArmSetpoint based on RobotGamePieceState
-    operator.x().onTrue(new ArmCommand(ArmSetpoint.PICKUP));
+    operator.x().onTrue(new ArmCommand(ArmSetpoint.PICKUP).alongWith(new PickupJoystickRumble(operator)));
     operator.a().onTrue(new ArmCommandSelector(getState, ArmPosition.GAME_PIECE_BOTTOM, false));
     operator.b().onTrue(new ArmCommandSelector(getState, ArmPosition.GAME_PIECE_MIDDLE, false));
     operator.y().onTrue(new ArmCommandSelector(getState, ArmPosition.GAME_PIECE_TOP, false));


### PR DESCRIPTION
It's really hard for Emily to see where the arm is when they're trying to pickup game pieces. This means it's hard to know if the arm is in a spot that can actually pickup a game piece.

Rumbles the operator joystick when the arm is close enough to the pickup position.

Closes #90 