### PR TITLE
Changed teleop speeds

### DIFF
--- a/src/main/java/frc/robot/commands/SwerveTeleop.java
+++ b/src/main/java/frc/robot/commands/SwerveTeleop.java
@@ -55,16 +55,16 @@ public class SwerveTeleop extends CommandBase {
 
         if(driverStick.leftBumper().getAsBoolean()){
             x = forwardLimiter.calculate(x);
-            x *= Config.Swerve.teleopFastSpeed;
+            x *= Config.Swerve.teleopLeftBumperSpeed;
         }
         else if(driverStick.rightBumper().getAsBoolean()){
             forwardLimiter.reset(0);
-            x *= Config.Swerve.teleopSlowSpeed;
+            x *= Config.Swerve.teleopRightBumperSpeed;
 
         }
         else{
             x = forwardLimiter.calculate(x);
-            x *= Config.Swerve.teleopSpeed;
+            x *= Config.Swerve.teleopDefaultSpeed;
         }
 
         return x;
@@ -79,17 +79,17 @@ public class SwerveTeleop extends CommandBase {
         }
 
         if(driverStick.leftBumper().getAsBoolean()){
-            y *= Config.Swerve.teleopFastSpeed;
+            y *= Config.Swerve.teleopLeftBumperSpeed;
             y = strafeLimiter.calculate(y); 
         }
         else if(driverStick.rightBumper().getAsBoolean()){
             strafeLimiter.reset(0); 
-            y *= Config.Swerve.teleopSlowSpeed;
+            y *= Config.Swerve.teleopRightBumperSpeed;
 
         }
         else{ 
             y = strafeLimiter.calculate(y); 
-            y *= Config.Swerve.teleopSpeed;
+            y *= Config.Swerve.teleopDefaultSpeed;
         }
         return y;
     }
@@ -105,16 +105,16 @@ public class SwerveTeleop extends CommandBase {
 
         if(driverStick.leftBumper().getAsBoolean()){
             rot = rotationLimiter.calculate(rot); 
-            rot *= Config.Swerve.teleopFastAngularSpeed;
+            rot *= Config.Swerve.teleopLeftBumperAngularSpeed;
         }
         else if(driverStick.rightBumper().getAsBoolean()){
             rotationLimiter.reset(0);
-            rot *= Config.Swerve.teleopSlowAngularSpeed;
+            rot *= Config.Swerve.teleopRightBumperAngularSpeed;
 
         }
         else{
             rot = rotationLimiter.calculate(rot); 
-            rot *= Config.Swerve.teleopAngularSpeed;
+            rot *= Config.Swerve.teleopDefaultAngularSpeed;
         }
         return rot;
 

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -205,7 +205,6 @@ public class Config {
 
         // Max speeds for desaturating
         public static final double kMaxAttainableWheelSpeed = 3.0; // Used by Auto, do not change.
-        public static final double kMaxAttainableAngularSpeed = Math.PI*3.0; // Only used for teleop
         
         // ~ Teleop speeds. Speeds should be portional to kMaxAttainableAngularSpeed. Angular speeds should be specified.
            

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -197,28 +197,38 @@ public class Config {
         public static DoubleSubscriber sub_steering_kD = NetworkTableInstance.getDefault().getTable("SwerveChassis/DrivePID").getDoubleTopic("Steering kD").subscribe(steering_kD);
         public static DoubleSubscriber sub_steering_kIZone = NetworkTableInstance.getDefault().getTable("SwerveChassis/DrivePID").getDoubleTopic("Steering kIzone").subscribe(steering_kIZone);
 
-        // Distance between centers of right and left wheels on robot
-
         public static final SwerveDriveKinematics kSwerveDriveKinematics = new SwerveDriveKinematics(
             new Translation2d(kWheelBase / 2, kTrackWidth / 2),
             new Translation2d(kWheelBase / 2, -kTrackWidth / 2),   
             new Translation2d(-kWheelBase / 2, kTrackWidth / 2),
             new Translation2d(-kWheelBase / 2, -kTrackWidth / 2));
 
-        public static final double teleopFastSpeed = 3.0;
-        public static final double teleopFastAngularSpeed = Math.PI*3.0;
+        // Max speeds for desaturating
+        public static final double kMaxAttainableWheelSpeed = 3.0; // Used by Auto, do not change.
+        public static final double kMaxAttainableAngularSpeed = Math.PI*3.0; // Only used for teleop
+        
+        // ~ Teleop speeds. Speeds should be portional to kMaxAttainableAngularSpeed. Angular speeds should be specified.
+           
+        // Default Speeds
+        public static final double teleopDefaultSpeed = kMaxAttainableWheelSpeed;// Full speed
+        public static final double teleopDefaultAngularSpeed = Math.PI*3.0; // Old value: Math.PI*2.0
 
-        public static final double teleopSlowSpeed = 0.3;
-        public static final double teleopSlowAngularSpeed = 0.3;
-        public static final double teleopSpeed = 2.0;
-        public static final double teleopAngularSpeed = Math.PI*2.0;
-        public static final double kMaxAttainableAngularSpeed = Math.PI*3.0;
-        public static final double kMaxAttainableWheelSpeed = 3.0;
+        // Left Bumper speeds
+        public static final double teleopLeftBumperSpeed = kMaxAttainableWheelSpeed / 3.0;// A third of full speed
+        public static final double teleopLeftBumperAngularSpeed = Math.PI; // Can be a slower angular speed if wanted
+
+        // Right bumper speeds
+        public static final double teleopRightBumperSpeed = 0.3;
+        public static final double teleopRightBumperAngularSpeed = 0.3;
+        
+
+        // Old PathWeaver speeds
         public static final double kMaxAutoSpeed = 3; // m/s
         public static final double kMaxAutoAcceleration = 3; // m/s/s
         public static final double kMaxAutoAngularSpeed = Math.PI *3; // rad/s
         public static final double kMaxAutoAngularAcceleration = Math.PI * 3; // rad/s/s
 
+        // Acceleration limit for teleop
         public static final double teleopRateLimit = 3;
 
         public static final double driveKS = 0.667;


### PR DESCRIPTION
Closes #116 

Renamed variables from slowSpeed, fastSpeed, etc to leftBumperSpeed, defaultSpeed, etc.

Default speed is now full speed. Default angular speed is now Math.PI\*3.0. @Jdiep7  Jamie, you might find this angular speed too fast, in which case it can be put back to the old angular speed of Math.PI\*2.0 without affecting the full speed for translational movements.

Left bumper speed is a third of full speed and angular speed is Math.PI.

Right bumper speed/angular speed is unchanged.

