### PR TITLE
detect cone with nose/base in before pick up cone

### DIFF
--- a/src/main/java/frc/robot/commands/GripperCommand.java
+++ b/src/main/java/frc/robot/commands/GripperCommand.java
@@ -98,15 +98,23 @@ public class GripperCommand extends InstantCommand {
     }
     case PICK_UP_CONE:
     {
-      takeCone();
+      
       if (newRobotState != null)
       {
         if (bConeNoseIn.get()==true)
+        {
           newRobotState.accept(RobotGamePieceState.HasNoseCone);
+          System.out.println("===== GripperCommand: detect noseIn");
+        }
         else
+        {
           newRobotState.accept(RobotGamePieceState.HasBaseCone);
+          System.out.println("===== GripperCommand: detect baseIn");
+        }
       }
-      //todo: ArmSubsystem needs to know nose/base cone
+
+      takeCone();
+      
       ArmSubsystem.getInstance().setHasCone(true);
       break;
     }


### PR DESCRIPTION
The intake camera detects the cone with nose or base in better when the cone is in the cutoff, before being picked up.