### PR TITLE
Fixed encoder syncing - Burn Flashes

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -141,7 +141,6 @@ public class Robot extends TimedRobot {
       
     if (SubsystemChecker.canSubsystemConstruct(SubsystemType.BlingSubsystem)) {
       if (m_firstDisableAtBootup) {
-        System.out.println("AAAAHHHHH");
         m_firstDisableAtBootup = false;
       } else {
         BlingSubsystem.getINSTANCE().setDisabled();

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -19,7 +19,9 @@ import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.robot.SubsystemChecker.SubsystemType;
 import frc.robot.commands.BrakeModeDisabled;
 import frc.robot.commands.CheckArmSetpoints;
+import frc.robot.commands.SetBlingCommand;
 import frc.robot.commands.SyncArmEncoders;
+import frc.robot.commands.SyncArmEncodersV2;
 import frc.robot.commands.SyncSteerEncoders;
 import frc.robot.config.Config;
 import frc.robot.robotcontainers.ArmBotContainer;
@@ -30,6 +32,7 @@ import frc.robot.robotcontainers.MergonautContainer;
 import frc.robot.robotcontainers.MiniNeoDiffContainer;
 import frc.robot.robotcontainers.MiniSwerveContainer;
 import frc.robot.robotcontainers.RobotContainer;
+import frc.robot.subsystems.BlingSubsystem;
 import frc.robot.subsystems.DiffNeoSubsystem;
 import frc.robot.subsystems.DiffTalonSubsystem;
 
@@ -45,6 +48,8 @@ public class Robot extends TimedRobot {
   private BrakeModeDisabled brakeModeDisabledCommand = null;
 
   Compressor pcmCompressor = new Compressor(1, PneumaticsModuleType.CTREPCM);
+
+  private boolean m_firstDisableAtBootup = true;
 
 
 
@@ -97,8 +102,9 @@ public class Robot extends TimedRobot {
     } 
     
     if (SubsystemChecker.canSubsystemConstruct(SubsystemType.SwerveSubsystem)) {
+      BlingSubsystem.getINSTANCE().setRed();
       new SyncSteerEncoders().schedule();
-      new WaitCommand(3).andThen(new SyncArmEncoders()).schedule();
+      new SyncArmEncodersV2().schedule();
     } 
 
     // Add CommandScheduler to shuffleboard so we can display what commands are scheduled
@@ -131,7 +137,16 @@ public class Robot extends TimedRobot {
   @Override
   public void disabledInit() {
     if (brakeModeDisabledCommand != null) 
-      brakeModeDisabledCommand.schedule();  
+      brakeModeDisabledCommand.schedule(); 
+      
+    if (SubsystemChecker.canSubsystemConstruct(SubsystemType.BlingSubsystem)) {
+      if (m_firstDisableAtBootup) {
+        System.out.println("AAAAHHHHH");
+        m_firstDisableAtBootup = false;
+      } else {
+        BlingSubsystem.getINSTANCE().setDisabled();
+      }
+    }
   }
 
   @Override

--- a/src/main/java/frc/robot/SubsystemChecker.java
+++ b/src/main/java/frc/robot/SubsystemChecker.java
@@ -34,11 +34,12 @@ public class SubsystemChecker {
      */
     // RobotID: 0, 2023 Competition robot, unnamed
     private static SubsystemType[] compBotId0 = new SubsystemType[] {
-        SubsystemType.SwerveSubsystem,  // Chassis unknown
+        SubsystemType.SwerveSubsystem,
         SubsystemType.ArmSubsystem,
         SubsystemType.RelaySubsystem,
         SubsystemType.VisionNTSubsystem,
         SubsystemType.GripperSubsystem,
+        SubsystemType.BlingSubsystem,
     };
 
     // RobotID: 1, 2022 robot, RapidReact, Clutch

--- a/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
+++ b/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
@@ -26,7 +26,7 @@ import frc.robot.subsystems.SwerveSubsystem;
 public class PhotonMoveToTarget extends CommandBase {
   double EXAMPLE_SIZE_HEIGHT = 104.6;
   double EXAMPLE_DISTANCE = 1.000;
-  Pose2d cameraOffset = new Pose2d(new Translation2d(0,0), Rotation2d.fromDegrees(0));
+  Pose2d cameraOffset = new Pose2d(new Translation2d(0,0.3), Rotation2d.fromDegrees(0));
   //height of april = 1 foot 3 and 1/4 to bottom of black
   /** Creates a new ExampleCommand. */
   DoubleArrayPublisher pubSetPoint;
@@ -74,7 +74,8 @@ public class PhotonMoveToTarget extends CommandBase {
       Rotation2d yaw = Rotation2d.fromDegrees(-result.getBestTarget().getYaw());  
 
       Translation2d visionXY = new Translation2d(range, yaw);
-      Translation2d robotToTargetRELATIVE = cameraOffset.getTranslation().plus(visionXY);
+      Translation2d robotRotated = visionXY.rotateBy(cameraOffset.getRotation());
+      Translation2d robotToTargetRELATIVE = robotRotated.plus(cameraOffset.getTranslation());
       Translation2d robotToTarget = robotToTargetRELATIVE.rotateBy(odometryPose.getRotation());
       Translation2d feildToTarget = robotToTarget.plus(odometryPose.getTranslation());
       //System.out.println("robot to target "+ robotToTargetRELATIVE.toString());

--- a/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
+++ b/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
@@ -4,8 +4,6 @@
 
 package frc.robot.commands;
 
-import javax.naming.spi.DirStateFactory.Result;
-
 import org.photonvision.PhotonCamera;
 import org.photonvision.PhotonUtils;
 
@@ -50,9 +48,9 @@ public class PhotonMoveToTarget extends CommandBase {
       System.out.println(range);
       System.out.println(yaw);
 
-    double xSpeed = xController.calculate(math.sin(yaw)*range, 2);
+    double xSpeed = xController.calculate(Math.sin(yaw)*range, 2);
     double turnSpeed = yawController.calculate(yaw, 0);
-    double yspeed = yController.calculate(math.cos(yaw)*range, 2);
+    double yspeed = yController.calculate(Math.cos(yaw)*range, 2);
     
       SwerveSubsystem.getInstance().drive(yspeed, xSpeed, turnSpeed, false, false);
                               }

--- a/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
+++ b/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
@@ -10,7 +10,9 @@ import org.photonvision.*;
 import org.photonvision.targeting.TargetCorner;
 
 import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.filter.LinearFilter;
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj2.command.CommandBase;
@@ -18,8 +20,9 @@ import frc.robot.subsystems.DiffTalonSubsystem;
 import frc.robot.subsystems.SwerveSubsystem;
 
 public class PhotonMoveToTarget extends CommandBase {
-  double EXAMPLE_SIZE_HEIGHT = 25.808;
-  double EXAMPLE_DISTANCE = 2.000;
+  double EXAMPLE_SIZE_HEIGHT = 104.6;
+  double EXAMPLE_DISTANCE = 1.000;
+  Pose2d cameraOffset = new Pose2d(new Translation2d(0.3,0.3), Rotation2d.fromDegrees(0));
   //height of april = 1 foot 3 and 1/4 to bottom of black
   /** Creates a new ExampleCommand. */
   PhotonCamera camera1;
@@ -27,19 +30,20 @@ public class PhotonMoveToTarget extends CommandBase {
   PIDController yController;
   PIDController yawController;
   Translation2d setPoint;
-  boolean seen = false;
+  LinearFilter filterX = LinearFilter.movingAverage(5);
+  LinearFilter filterY = LinearFilter.movingAverage(5);
+
 
   public PhotonMoveToTarget() {
     camera1 = new PhotonCamera("OV9281");
-    xController = new PIDController(0.7, 0, 0);
-    yController = new PIDController(0.7, 0, 0);
+    xController = new PIDController(1.2, 0, 0);
+    yController = new PIDController(1.2, 0, 0);
     yawController = new PIDController(0.06, 0, 5);
   }
 
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
-    seen = false;
   }
 
   // Called every time the scheduler runs while the command is scheduled.
@@ -50,24 +54,26 @@ public class PhotonMoveToTarget extends CommandBase {
     if (result.hasTargets()){
       List<TargetCorner> corners = result.getBestTarget().getDetectedCorners();
       double heightSize = (corners.get(0).y - corners.get(3).y + corners.get(1).y - corners.get(2).y)/2;
-      double range = heightSize/EXAMPLE_SIZE_HEIGHT*EXAMPLE_DISTANCE;
-      double yaw = -result.getBestTarget().getYaw() + odometryPose.getRotation().getDegrees();
-
-      double targetX = Math.cos(yaw)*range + odometryPose.getX()-1;
-      System.out.println("range: " + range + " cos: " + Math.cos(yaw) + " Odometry: " + odometryPose.getX());
-      double targetY = Math.sin(yaw)*range + odometryPose.getY();
-      if (seen == false)
-        setPoint = new Translation2d((targetX),(targetY));
-      if (seen) 
-        setPoint = new Translation2d((setPoint.getX()+targetX)/2,(setPoint.getY()+targetY)/2);
-      seen = true;
-      }
-      if (seen) {
+      System.out.println(heightSize);
+      double range = EXAMPLE_SIZE_HEIGHT*EXAMPLE_DISTANCE/heightSize;
+      System.out.println("range"+range);
+      Rotation2d yaw = Rotation2d.fromDegrees(-result.getBestTarget().getYaw()); //+ odometryPose.getRotation().getDegrees());
+      
+      Translation2d visionXY = new Translation2d(range, yaw);
+      Translation2d robotToTargetRELATIVE = cameraOffset.getTranslation().plus(visionXY);
+      Translation2d robotToTarget = robotToTargetRELATIVE.rotateBy(odometryPose.getRotation());
+      Translation2d feildToTarget = robotToTarget.plus(odometryPose.getTranslation());
+      System.out.println("robot to target "+ robotToTargetRELATIVE.toString());
+      System.out.println("odometry"+ odometryPose.toString());
+      
+      setPoint = new Translation2d(filterX.calculate(feildToTarget.getX())-1,filterY.calculate(feildToTarget.getY()));
+      System.out.println("set "+setPoint);
+    }
       double xSpeed = xController.calculate(odometryPose.getX(), setPoint.getX());
       double yspeed = yController.calculate(odometryPose.getY(), setPoint.getY());
       SwerveSubsystem.getInstance().drive(xSpeed, yspeed, 0, true, false);
-      }
-    }
+  }
+  
 
   // Called once the command ends or is interrupted.
   @Override

--- a/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
+++ b/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
@@ -10,50 +10,64 @@ import org.photonvision.*;
 import org.photonvision.targeting.TargetCorner;
 
 import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.DiffTalonSubsystem;
 import frc.robot.subsystems.SwerveSubsystem;
 
 public class PhotonMoveToTarget extends CommandBase {
-    double EXAMPLE_SIZE_HEIGHT = 25.808;
-    double EXAMPLE_DISTANCE = 2.000;
-    //height of april = 1 foot 3 and 1/4
+  double EXAMPLE_SIZE_HEIGHT = 25.808;
+  double EXAMPLE_DISTANCE = 2.000;
+  //height of april = 1 foot 3 and 1/4 to bottom of black
   /** Creates a new ExampleCommand. */
   PhotonCamera camera1;
   PIDController xController;
   PIDController yController;
   PIDController yawController;
+  Translation2d setPoint;
+  boolean seen = false;
+
   public PhotonMoveToTarget() {
     camera1 = new PhotonCamera("OV9281");
     xController = new PIDController(0.7, 0, 0);
     yController = new PIDController(0.7, 0, 0);
     yawController = new PIDController(0.06, 0, 5);
-}
+  }
 
   // Called when the command is initially scheduled.
   @Override
-  public void initialize() {}
+  public void initialize() {
+    seen = false;
+  }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
     var result = camera1.getLatestResult();
+    Pose2d odometryPose = SwerveSubsystem.getInstance().getPose();
     if (result.hasTargets()){
       List<TargetCorner> corners = result.getBestTarget().getDetectedCorners();
-      double height = (corners.get(0).y - corners.get(3).y + corners.get(1).y - corners.get(2).y)/2;
-      double range = height/EXAMPLE_SIZE_HEIGHT*EXAMPLE_DISTANCE;
-      double yaw = result.getBestTarget().getYaw();
-      System.out.println(range);
-      System.out.println(yaw);
+      double heightSize = (corners.get(0).y - corners.get(3).y + corners.get(1).y - corners.get(2).y)/2;
+      double range = heightSize/EXAMPLE_SIZE_HEIGHT*EXAMPLE_DISTANCE;
+      double yaw = -result.getBestTarget().getYaw() + odometryPose.getRotation().getDegrees();
 
-    double xSpeed = xController.calculate(Math.cos(yaw)*range, 2);
-    //double turnSpeed = yawController.calculate(yaw, 0);
-    double yspeed = yController.calculate(Math.sin(yaw)*range, 2);
-    
-      SwerveSubsystem.getInstance().drive(xSpeed, yspeed, 0, false, false);
-                              }
-  }
+      double targetX = Math.cos(yaw)*range + odometryPose.getX()-1;
+      System.out.println("range: " + range + " cos: " + Math.cos(yaw) + " Odometry: " + odometryPose.getX());
+      double targetY = Math.sin(yaw)*range + odometryPose.getY();
+      if (seen == false)
+        setPoint = new Translation2d((targetX),(targetY));
+      if (seen) 
+        setPoint = new Translation2d((setPoint.getX()+targetX)/2,(setPoint.getY()+targetY)/2);
+      seen = true;
+      }
+      if (seen) {
+      double xSpeed = xController.calculate(odometryPose.getX(), setPoint.getX());
+      double yspeed = yController.calculate(odometryPose.getY(), setPoint.getY());
+      SwerveSubsystem.getInstance().drive(xSpeed, yspeed, 0, true, false);
+      }
+    }
 
   // Called once the command ends or is interrupted.
   @Override

--- a/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
+++ b/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
@@ -25,7 +25,8 @@ public class PhotonMoveToTarget extends CommandBase {
   PIDController yawController;
   public PhotonMoveToTarget() {
     camera1 = new PhotonCamera("OV9281");
-    rangeController = new PIDController(-.7, 0, 0);
+    xController = new PIDController(-.7, 0, 0);
+    yController = new PIDController(-.7, 0, 0);
     yawController = new PIDController(0.06, 0, 5);
 }
 
@@ -48,10 +49,12 @@ public class PhotonMoveToTarget extends CommandBase {
                                 double yaw = result.getBestTarget().getYaw();
       System.out.println(range);
       System.out.println(yaw);
-    double forwardSpeed = rangeController.calculate(range, 2);
-    double turnSpeed = yawController.calculate(yaw,0);
+
+    double xSpeed = xController.calculate(math.sin(yaw)*range, 2);
+    double turnSpeed = yawController.calculate(yaw, 0);
+    double yspeed = yController.calculate(math.cos(yaw)*range, 2);
     
-      SwerveSubsystem.getInstance().drive(forwardSpeed, 0, turnSpeed, false, false);
+      SwerveSubsystem.getInstance().drive(yspeed, xSpeed, turnSpeed, false, false);
                               }
   }
 

--- a/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
+++ b/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
@@ -1,0 +1,67 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import javax.naming.spi.DirStateFactory.Result;
+
+import org.photonvision.PhotonCamera;
+import org.photonvision.PhotonUtils;
+
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.DiffTalonSubsystem;
+
+public class PhotonMoveToTarget extends CommandBase {
+    double CAMERA_HEIGHT_METERS = 0.255;
+    double TARGET_HEIGHT_METERS = 0.85;
+    double CAMERA_PITCH_RADIANS = Units.degreesToRadians(14);
+  /** Creates a new ExampleCommand. */
+  PhotonCamera camera1;
+  PIDController rangeController;
+  PIDController yawController;
+  public PhotonMoveToTarget() {
+    camera1 = new PhotonCamera("OV9281");
+    rangeController = new PIDController(-.7, 0, 0);
+    yawController = new PIDController(0.06, 0, 5);
+}
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {}
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    var result = camera1.getLatestResult();
+    if (result.hasTargets()){
+        double range =
+                        PhotonUtils.calculateDistanceToTargetMeters(
+                                CAMERA_HEIGHT_METERS,
+                                TARGET_HEIGHT_METERS,
+                                CAMERA_PITCH_RADIANS,
+                                Units.degreesToRadians(result.getBestTarget().getPitch()));
+        
+                                double yaw = result.getBestTarget().getYaw();
+      System.out.println(range);
+      System.out.println(yaw);
+    double forwardSpeed = rangeController.calculate(range, 2);
+    double turnSpeed = yawController.calculate(yaw,0);
+    
+      DiffTalonSubsystem.getInstance().arcadeDrive(forwardSpeed, turnSpeed);
+
+                              }
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
+++ b/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
@@ -13,6 +13,7 @@ import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.DiffTalonSubsystem;
+import frc.robot.subsystems.SwerveSubsystem;
 
 public class PhotonMoveToTarget extends CommandBase {
     double CAMERA_HEIGHT_METERS = 0.255;
@@ -50,14 +51,15 @@ public class PhotonMoveToTarget extends CommandBase {
     double forwardSpeed = rangeController.calculate(range, 2);
     double turnSpeed = yawController.calculate(yaw,0);
     
-      DiffTalonSubsystem.getInstance().arcadeDrive(forwardSpeed, turnSpeed);
-
+      SwerveSubsystem.getInstance().drive(forwardSpeed, 0, turnSpeed, false, false);
                               }
   }
 
   // Called once the command ends or is interrupted.
   @Override
-  public void end(boolean interrupted) {}
+  public void end(boolean interrupted) {
+    SwerveSubsystem.getInstance().stopMotors();
+  }
 
   // Returns true when the command should end.
   @Override

--- a/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
+++ b/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
@@ -4,8 +4,10 @@
 
 package frc.robot.commands;
 
-import org.photonvision.PhotonCamera;
-import org.photonvision.PhotonUtils;
+import java.util.List;
+
+import org.photonvision.*;
+import org.photonvision.targeting.TargetCorner;
 
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.util.Units;
@@ -14,17 +16,18 @@ import frc.robot.subsystems.DiffTalonSubsystem;
 import frc.robot.subsystems.SwerveSubsystem;
 
 public class PhotonMoveToTarget extends CommandBase {
-    double CAMERA_HEIGHT_METERS = 0.255;
-    double TARGET_HEIGHT_METERS = 0.85;
-    double CAMERA_PITCH_RADIANS = Units.degreesToRadians(14);
+    double EXAMPLE_SIZE_HEIGHT = 25.808;
+    double EXAMPLE_DISTANCE = 2.000;
+    //height of april = 1 foot 3 and 1/4
   /** Creates a new ExampleCommand. */
   PhotonCamera camera1;
-  PIDController rangeController;
+  PIDController xController;
+  PIDController yController;
   PIDController yawController;
   public PhotonMoveToTarget() {
     camera1 = new PhotonCamera("OV9281");
-    xController = new PIDController(-.7, 0, 0);
-    yController = new PIDController(-.7, 0, 0);
+    xController = new PIDController(0.7, 0, 0);
+    yController = new PIDController(0.7, 0, 0);
     yawController = new PIDController(0.06, 0, 5);
 }
 
@@ -37,22 +40,18 @@ public class PhotonMoveToTarget extends CommandBase {
   public void execute() {
     var result = camera1.getLatestResult();
     if (result.hasTargets()){
-        double range =
-                        PhotonUtils.calculateDistanceToTargetMeters(
-                                CAMERA_HEIGHT_METERS,
-                                TARGET_HEIGHT_METERS,
-                                CAMERA_PITCH_RADIANS,
-                                Units.degreesToRadians(result.getBestTarget().getPitch()));
-        
-                                double yaw = result.getBestTarget().getYaw();
+      List<TargetCorner> corners = result.getBestTarget().getDetectedCorners();
+      double height = (corners.get(0).y - corners.get(3).y + corners.get(1).y - corners.get(2).y)/2;
+      double range = height/EXAMPLE_SIZE_HEIGHT*EXAMPLE_DISTANCE;
+      double yaw = result.getBestTarget().getYaw();
       System.out.println(range);
       System.out.println(yaw);
 
-    double xSpeed = xController.calculate(Math.sin(yaw)*range, 2);
-    double turnSpeed = yawController.calculate(yaw, 0);
-    double yspeed = yController.calculate(Math.cos(yaw)*range, 2);
+    double xSpeed = xController.calculate(Math.cos(yaw)*range, 2);
+    //double turnSpeed = yawController.calculate(yaw, 0);
+    double yspeed = yController.calculate(Math.sin(yaw)*range, 2);
     
-      SwerveSubsystem.getInstance().drive(yspeed, xSpeed, turnSpeed, false, false);
+      SwerveSubsystem.getInstance().drive(xSpeed, yspeed, 0, false, false);
                               }
   }
 

--- a/src/main/java/frc/robot/commands/ResetGyro.java
+++ b/src/main/java/frc/robot/commands/ResetGyro.java
@@ -6,6 +6,7 @@ package frc.robot.commands;
 
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.SwerveDriveOdometry;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.SwerveSubsystem;
@@ -24,8 +25,7 @@ public class ResetGyro extends CommandBase {
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
-    Pose2d pose = SwerveSubsystem.getInstance().getPose();
-    Pose2d newPose = new Pose2d(pose.getTranslation(), new Rotation2d(0));
+    Pose2d newPose = new Pose2d(new Translation2d(3, 3), new Rotation2d(0));
     SwerveSubsystem.getInstance().resetOdometry(newPose);
   }
 

--- a/src/main/java/frc/robot/commands/SyncArmEncodersV2.java
+++ b/src/main/java/frc/robot/commands/SyncArmEncodersV2.java
@@ -1,0 +1,150 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj2.command.Commands;
+import edu.wpi.first.wpilibj2.command.WaitCommand;
+import frc.robot.config.ArmConfig;
+import frc.robot.subsystems.ArmSubsystem;
+import frc.robot.subsystems.BlingSubsystem;
+
+public class SyncArmEncodersV2 extends CommandBase {
+    private Timer m_smallTimer = new Timer();
+    private Timer m_permanantTimer = new Timer();
+    private int m_commandState = 0;
+    private int m_numSamples = 0;
+    private double m_sumBotSamples = 0;
+    private double m_sumTopSamples = 0;
+
+    /** Creates a new SyncSteerEncoders. */
+    public SyncArmEncodersV2() {
+        addRequirements(ArmSubsystem.getInstance());
+    }
+
+    // Called when the command is initially scheduled.
+    @Override
+    public void initialize() {
+        m_smallTimer.restart();
+        m_permanantTimer.restart();
+        m_numSamples = 0;
+        m_sumBotSamples = 0;
+        m_sumTopSamples = 0;
+        m_commandState = 0;
+        
+        BlingSubsystem.getINSTANCE().noEncodersSynced();
+    }
+
+    // Called every time the scheduler runs while the command is scheduled.
+    @Override
+    public void execute() {
+        if (m_smallTimer.get() > ArmConfig.ENCODER_SYNCING_PERIOD_V2) {
+            m_smallTimer.reset();
+
+            if (m_commandState == 0 && m_permanantTimer.hasElapsed(1)) {
+                DriverStation.reportWarning(
+                    String.format("Arm encoders are not synced, collecting arm encoder samples... (%.1fs)", m_permanantTimer.get()),
+                    false);
+
+                m_commandState = 1;
+
+            } else if (m_commandState == 1) {
+                m_sumBotSamples += ArmSubsystem.getInstance().getAbsoluteBottom();
+                m_sumTopSamples += ArmSubsystem.getInstance().getAbsoluteTop();
+                m_numSamples++;
+
+                if (m_numSamples >= ArmConfig.NUM_SYNCING_SAMPLES) {
+                    m_commandState = 2;
+                }
+            } else if (m_commandState == 2) {
+                ArmSubsystem.getInstance().resetEncoder(
+                    m_sumBotSamples / m_numSamples,
+                    m_sumTopSamples / m_numSamples
+                );
+
+                if (ArmSubsystem.getInstance().areEncodersSynced() == false) {
+                    DriverStation.reportWarning(
+                        String.format("Arm encoders are not synced, attempting to sync them... (%.1fs)", m_permanantTimer.get()),
+                        false);
+                    
+                } else {
+                    m_commandState = 99; // End the command, the encoders are synced
+                }
+            }
+        }
+    }
+
+    // Called once the command ends or is interrupted.
+    @Override
+    public void end(boolean interrupted) {
+        if (m_commandState == 99) {
+            DriverStation.reportWarning(
+                        String.format("Arm encoders are synced (%.1f) \n", m_permanantTimer.get()),
+                        false);    
+            
+            BlingSubsystem.getINSTANCE().armEncodersSynced();
+
+            new WaitCommand(1).andThen(
+                Commands.runOnce(() -> BlingSubsystem.getINSTANCE().armEncodersSynced()),
+                new WaitCommand(1),
+                Commands.runOnce(() -> BlingSubsystem.getINSTANCE().armEncodersSynced())
+            ).schedule();
+
+            ArmSubsystem.getInstance().sparkMaxBurnFlash();
+        }
+
+        m_permanantTimer.stop();
+        m_smallTimer.stop();
+
+        if (           
+            /** Temporary checks for current encoder setup. TODO: Remove once encoder wrapping is solved.*/
+            ArmSubsystem.getInstance().getBottomPosition() < Math.toRadians(5) ||
+            ArmSubsystem.getInstance().getBottomPosition() > Math.toRadians(170) ||
+            ArmSubsystem.getInstance().getTopPosition() < Math.toRadians(5) ||
+            ArmSubsystem.getInstance().getTopPosition() > Math.toRadians(70) ||
+            ArmSubsystem.getInstance().areEncodersSynced() == false ||
+            m_commandState != 99
+            ) {
+            
+            DriverStation.reportError("Arm encoders were reset outside the proper range. " +
+                    " Disabling the arm to prevent damage." +
+                    " Make sure the code boots up with the arm in the reset position.", true);
+
+            // This line below will prevent any commands from being scheduled to the ArmSubsystem.
+            // This line is temporary while we haven't properly setup the absolute encoders properly yet.
+            // If it's blocking you from using the arm, you just need to put the arm in the reset position
+            //    and reboot the code (which will properly reset the NEO encoders the absolute encoders).
+            Commands.run(() -> ArmSubsystem.getInstance(), ArmSubsystem.getInstance()).withInterruptBehavior(InterruptionBehavior.kCancelIncoming).ignoringDisable(true).schedule();
+        }
+    }
+
+    // Returns true when the command should end.
+    @Override
+    public boolean isFinished() {
+        if (m_permanantTimer.get() > ArmConfig.ENCODER_SYNCING_TIMEOUT)  {
+            DriverStation.reportError(
+                String.format("Arm encoders are not synced. SyncArmEncodersV2 spent %.1fs trying to sync them and has timed out",
+                m_permanantTimer.get()),
+                false);
+
+            return true;
+        }
+        return m_commandState == 99;
+    }
+
+    @Override
+    public boolean runsWhenDisabled() {
+        return true;
+    }
+
+    @Override
+    public InterruptionBehavior getInterruptionBehavior() {
+        DriverStation.reportWarning("Another ArmSubsystem command was scheduled while " +
+                "SyncArmEncodersV2 is still running. Cancelling the incoming command.", false);
+        return InterruptionBehavior.kCancelIncoming;
+    }
+}

--- a/src/main/java/frc/robot/commands/SyncSteerEncoders.java
+++ b/src/main/java/frc/robot/commands/SyncSteerEncoders.java
@@ -43,7 +43,7 @@ public class SyncSteerEncoders extends CommandBase {
     @Override
     public void execute() {
         SmartDashboard.putNumber("SyncSteerState", state);
-        if (state == 0 && m_permanantTimer.hasElapsed(6)) {
+        if (state == 0 && m_permanantTimer.hasElapsed(1)) {
             state = 1;
             DriverStation.reportWarning(
                     String.format("Starting to sync steer encoders (%.1fs)", m_permanantTimer.get()), false);
@@ -57,14 +57,16 @@ public class SyncSteerEncoders extends CommandBase {
                     false);
                 SwerveSubsystem.getInstance().resetEncodersFromCanCoder();
             } else {
-                state = 2;
+                state = 99;
                 m_smallTimer.restart();
             }
         }
-        if (state == 2 && m_smallTimer.hasElapsed(5)) {
-            SwerveSubsystem.getInstance().resetEncodersFromCanCoder();
-            state = 99;
-        }
+        // if (state == 2 && m_smallTimer.hasElapsed(1)) {
+        //     if (SwerveSubsystem.getInstance().checkSteeringEncoders() == false) {
+        //         SwerveSubsystem.getInstance().resetEncodersFromCanCoder();
+        //     }
+        //     state = 99;
+        // }
         SmartDashboard.putNumber("SyncSteerState", state);
     }
 
@@ -77,7 +79,11 @@ public class SyncSteerEncoders extends CommandBase {
                         false);
             BlingSubsystem.getINSTANCE().steerEncodersSynced();
 
-            new WaitCommand(1).andThen(Commands.runOnce(() -> BlingSubsystem.getINSTANCE().steerEncodersSynced())).schedule();
+            new WaitCommand(1).andThen(
+                Commands.runOnce(() -> BlingSubsystem.getINSTANCE().steerEncodersSynced()),
+                new WaitCommand(1),
+                Commands.runOnce(() -> BlingSubsystem.getINSTANCE().steerEncodersSynced())
+            ).schedule();
         }
 
         m_permanantTimer.stop();

--- a/src/main/java/frc/robot/config/ArmConfig.java
+++ b/src/main/java/frc/robot/config/ArmConfig.java
@@ -204,6 +204,7 @@ public class ArmConfig {
 
       // Syncing encoders
       public static double ENCODER_SYNCING_PERIOD = 0.4; // seconds
+      public static double ENCODER_SYNCING_PERIOD_V2 = 0.05; // seconds
       public static int ENCODER_SYNCING_TIMEOUT = 20; // seconds
       public static double ENCODER_SYNCING_TOLERANCE = 0.01; // radians
       public static int NUM_SYNCING_SAMPLES = 20; // num of samples needed to average

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -208,13 +208,16 @@ public class Config {
         
         // ~ Teleop speeds. Speeds should be portional to kMaxAttainableAngularSpeed. Angular speeds should be specified.
            
+        // REDUCING THE SPEED OF THE ROBOT SO WE DON"T DAMAGE SPONSER'S CARPET
+        public static final double OUTREACH_SPEED_REDUCTION = 0.4;
+
         // Default Speeds
-        public static final double teleopDefaultSpeed = kMaxAttainableWheelSpeed;// Full speed
-        public static final double teleopDefaultAngularSpeed = Math.PI*3.0; // Old value: Math.PI*2.0
+        public static final double teleopDefaultSpeed = kMaxAttainableWheelSpeed * OUTREACH_SPEED_REDUCTION;// Full speed
+        public static final double teleopDefaultAngularSpeed = Math.PI*3.0 * OUTREACH_SPEED_REDUCTION; // Old value: Math.PI*2.0
 
         // Left Bumper speeds
-        public static final double teleopLeftBumperSpeed = kMaxAttainableWheelSpeed / 3.0;// A third of full speed
-        public static final double teleopLeftBumperAngularSpeed = Math.PI; // Can be a slower angular speed if wanted
+        public static final double teleopLeftBumperSpeed = kMaxAttainableWheelSpeed / 3.0 * OUTREACH_SPEED_REDUCTION;// A third of full speed
+        public static final double teleopLeftBumperAngularSpeed = Math.PI * OUTREACH_SPEED_REDUCTION; // Can be a slower angular speed if wanted
 
         // Right bumper speeds
         public static final double teleopRightBumperSpeed = 0.3;

--- a/src/main/java/frc/robot/robotcontainers/CompRobotContainer.java
+++ b/src/main/java/frc/robot/robotcontainers/CompRobotContainer.java
@@ -92,8 +92,8 @@ public class CompRobotContainer extends RobotContainer {
     driver.back().onTrue(new ResetGyro());
 
     driver.y().whileTrue(new RotateAngleXY(driver, 0));
-    driver.a().whileTrue(new RotateAngleXY(driver, Math.PI));
-    
+
+    driver.a().whileTrue(new PhotonMoveToTarget());    
     driver.x().whileTrue(new ChargeStationLock());
     driver.leftTrigger().whileTrue(new RotateXYSupplier(driver,
       NetworkTableInstance.getDefault().getTable("MergeVisionPipelineIntake22").getDoubleTopic("Yaw").subscribe(-99)

--- a/src/main/java/frc/robot/robotcontainers/CompRobotContainer.java
+++ b/src/main/java/frc/robot/robotcontainers/CompRobotContainer.java
@@ -93,8 +93,7 @@ public class CompRobotContainer extends RobotContainer {
     driver.back().onTrue(new ResetGyro());
 
     driver.y().whileTrue(new RotateAngleXY(driver, 0));
-
-    driver.a().whileTrue(new PhotonMoveToTarget());    
+    driver.a().whileTrue(new PhotonMoveToTarget());
     driver.x().whileTrue(new ChargeStationLock());
     driver.leftTrigger().whileTrue(new RotateXYSupplier(driver,
       NetworkTableInstance.getDefault().getTable("MergeVisionPipelineIntake22").getDoubleTopic("Yaw").subscribe(-99)

--- a/src/main/java/frc/robot/robotcontainers/CompRobotContainer.java
+++ b/src/main/java/frc/robot/robotcontainers/CompRobotContainer.java
@@ -27,6 +27,7 @@ import frc.robot.commands.ArmCommandSelector;
 import frc.robot.commands.ChargeStationLock;
 import frc.robot.commands.DriveArmAgainstBackstop;
 import frc.robot.commands.GripperCommand;
+import frc.robot.commands.PhotonMoveToTarget;
 import frc.robot.commands.GripperCommand.GRIPPER_INSTRUCTION;
 import frc.robot.commands.ResetGyro;
 import frc.robot.commands.RotateAngleXY;

--- a/src/main/java/frc/robot/subsystems/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ArmSubsystem.java
@@ -242,8 +242,11 @@ public class ArmSubsystem extends SubsystemBase {
     m_bottomArmFFTestingVolts = bottomArmDataTable.getDoubleTopic("VoltageSetInFFTesting").publish();
 
     updatePIDSettings();
-    updateFromAbsoluteTop();
-    updateFromAbsoluteBottom();
+  }
+
+  public void sparkMaxBurnFlash() {
+    m_bottomArm.burnFlash();
+    m_topArm.burnFlash();
   }
 
   public void updatePIDSettings() {

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -58,16 +58,14 @@ public class SwerveSubsystem extends SubsystemBase {
     ProfiledPIDController pidControlX;
     double currentX;
     double desiredX;
-    
     ProfiledPIDController pidControlY;
     double currentY;
     double desiredY;
-
     ProfiledPIDController pidControlRotation;
     double currentRotation;
     double desiredRotation;
-
-    double tolerance;
+    double tolerance = 0.01;
+    double angleTolerance = 0.01;
 
     /** Get instance of singleton class */
     public static SwerveSubsystem getInstance() {
@@ -299,35 +297,22 @@ public class SwerveSubsystem extends SubsystemBase {
     }
 
     // Swerve actual driving methods
-    public void resetDriveToPose(double deltaX, double deltaY, double toleranceIn) {
-        // odometry - get x, y, and rotation
-        currentX = getPose().getX();
-        currentY = getPose().getY();
-        currentRotation = getHeading().getRadians();
-
-        // set desired x, y, and rotation
-        desiredX = currentX + deltaX;
-        desiredY = currentY + deltaY;
-        // rotation stays the same
-        desiredRotation = currentRotation;
-
+    public void resetDriveToPose() {
         // reset current positions
         pidControlX.reset(currentX);
         pidControlY.reset(currentY);
         pidControlRotation.reset(currentRotation);
-
-        // set tolerance
-        tolerance = toleranceIn;
-        pidControlX.setTolerance(tolerance, tolerance);
-        pidControlY.setTolerance(tolerance, tolerance);
-        pidControlRotation.setTolerance(tolerance, tolerance);
     }
 
-    public void driveToPose() {
+    public void driveToPose(Pose2d pose) {
         //update the currentX and currentY
         currentX = getPose().getX();
         currentY = getPose().getY();
         currentRotation = getHeading().getRadians();
+
+        desiredX = pose.getX();
+        desiredY = pose.getY();
+        desiredRotation = pose.getRotation().getRadians();
 
         double x = pidControlX.calculate(currentX, desiredX);
         double y = pidControlY.calculate(currentY, desiredY);
@@ -338,6 +323,6 @@ public class SwerveSubsystem extends SubsystemBase {
 
     public boolean isAtPose() {
         return Math.abs(currentX - desiredX) < tolerance && Math.abs(currentY - desiredY) < tolerance
-                && Math.abs(currentRotation - desiredRotation) < tolerance;
+                && Math.abs(currentRotation - desiredRotation) < angleTolerance;
     }
 }

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -15,9 +15,11 @@ import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.DoubleArrayPublisher;
 import edu.wpi.first.networktables.DoubleEntry;
 import edu.wpi.first.networktables.DoublePublisher;
 import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.PubSub;
 import edu.wpi.first.networktables.PubSubOption;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -38,7 +40,8 @@ public class SwerveSubsystem extends SubsystemBase {
 
     private DoublePublisher pitchPub = table.getDoubleTopic("Pitch").publish();
     private DoublePublisher rollPub = table.getDoubleTopic("Roll").publish();
-    
+
+    private DoubleArrayPublisher pubOdometry = table.getDoubleArrayTopic("OdometryArr").publish(PubSubOption.periodic(0.02));
     // Instance for singleton class
     private static SwerveSubsystem instance;
 
@@ -102,6 +105,8 @@ public class SwerveSubsystem extends SubsystemBase {
 
         pitchPub.accept(getPitch());
         rollPub.accept(getRoll());
+
+        pubOdometry.accept(new double[]{getPose().getX(), getPose().getY(), getPose().getRotation().getRadians()});
     }
 
     private SwerveModulePosition[] getPosition() {

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,0 +1,41 @@
+{
+    "fileName": "photonlib.json",
+    "name": "photonlib",
+    "version": "v2023.4.2",
+    "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004 ",
+    "mavenUrls": [
+        "https://maven.photonvision.org/repository/internal",
+        "https://maven.photonvision.org/repository/snapshots"
+    ],
+    "jsonUrl": "https://maven.photonvision.org/repository/internal/org/photonvision/PhotonLib-json/1.0/PhotonLib-json-1.0.json",
+    "jniDependencies": [],
+    "cppDependencies": [
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "PhotonLib-cpp",
+            "version": "v2023.4.2",
+            "libName": "Photon",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxathena",
+                "linuxx86-64",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "javaDependencies": [
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "PhotonLib-java",
+            "version": "v2023.4.2"
+        },
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "PhotonTargeting-java",
+            "version": "v2023.4.2"
+        }
+    ]
+}


### PR DESCRIPTION
Reordered burn flashing and encoder syncing. Now it will completely finish doing the encoder syncing and then call burn flash on the sparkmaxes.

It seems that calling burnFlash on the sparkmax was holding up the sparkmax while the encoder syncing was trying to be done. So now burnFlash runs after all the initial setup at bootup is complete.

I rebooted many times to verify this fixed the issue.